### PR TITLE
Detect recovery from failed notifications

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -150,9 +150,44 @@ module.exports = class Client extends EventEmitter {
     try {
       message = decrypt(object, this._credentials.keys);
     } catch (error) {
+      // NOTE(ibash) we seem to be getting errors while decrypting. I want to
+      // know if these errors are recoverable, whether it's just a single
+      // notification that will fail or if it's all notifications going forward.
+      // So we keep track of whether we've just seen a failed notification and
+      // whether we get a notification that goes through after that.
+
+      // Put the object in _persistentIds so we ignore a failed notification next time
+      this._persistentIds.push(object.persistentId);
+
+      // For detecting whether we can recover after failing to decrypt
+      this._failedToDecrypt = {object: object, keys: this._credentials.keys}
+
       error.metaData = {message: JSON.stringify(object), keys: JSON.stringify(this._credentials.keys)}
-      throw error
+      // throw in a setTimeout s.t. bugsnag can catch the error, but we don't
+      // want to break the connection
+      setTimeout(() => {
+        throw error
+      }, 0)
+      return
     }
+
+    // detect if we've recovered from a failed notification
+    if (this._failedToDecrypt && this._credentials.keys.privateKey == this._failedToDecrypt.keys.privateKey) {
+      let failedToDecrypt = this._failedToDecrypt
+      this._failedToDecrypt = null
+      let keys = this._credentials.keys
+      setTimeout(() => {
+        // HACK(ibash) this should really log somewhere instead but ... bugsnag
+        // is my log :D
+        let error = new Error('Recovered from failure to decrypt notification')
+        error.metaData = {
+          failed: {message: JSON.stringify(failedToDecrypt.object), keys: JSON.stringify(failedToDecrypt.keys)},
+          succeeded: {message: JSON.stringify(object), keys: JSON.stringify(keys)},
+        }
+        throw error
+      }, 0)
+    }
+
     // Maintain persistentIds updated with the very last received value
     this._persistentIds.push(object.persistentId);
     // Send notification


### PR DESCRIPTION
This attempts to detect if we can recover from failed notifications by
checking if we go from failed notification to a non-failed notification
(for the same keys).

In addition this adds the persistentId of a failed notification to our
list of handled push notifications so that we don't try to keep
processing the same failed notification.