### PR TITLE
 Silently drop notifications that cannot be decrypted

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "yargs": "^10.0.3"
   },
   "dependencies": {
-    "electron-log": "^2.2.14",
     "http_ece": "^1.0.5",
     "long": "^3.2.0",
     "protobufjs": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/push-receiver",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "A module to subscribe to GCM/FCM and receive notifications within a node process.",
   "main": "src/index.js",
   "scripts": {

--- a/src/fcm/index.js
+++ b/src/fcm/index.js
@@ -1,10 +1,6 @@
 const crypto = require('crypto');
 const request = require('request-promise');
-const log = require('electron-log');
 const { escape } = require('../utils/base64');
-
-log.transports.console.level = 'info';
-log.transports.file.level = 'info';
 
 const FCM_SUBSCRIBE = 'https://fcm.googleapis.com/fcm/connect/subscribe';
 const FCM_ENDPOINT = 'https://fcm.googleapis.com/fcm/send';
@@ -13,7 +9,6 @@ module.exports = registerFCM;
 
 async function registerFCM({ senderId, token }) {
   const keys = await createKeys();
-  log.info('CREATED KEYS', keys)
   const response = await request({
     url     : FCM_SUBSCRIBE,
     method  : 'POST',

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,10 +452,6 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-electron-log@^2.2.14:
-  version "2.2.14"
-  resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-2.2.14.tgz#2123319ccb8d70b0db07f0eda57d5823cb42b4b0"
-
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"


### PR DESCRIPTION
We are unable to decrypt some notifications. When testing in production we are able to receive future notifications, though. So silently drop these notifications and add them to the persistentIds so we don't try to re-process them.