### PR TITLE
Clear persistent ids after logging in

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -155,6 +155,13 @@ module.exports = class Client extends EventEmitter {
         // all cases we've been able to receive future notifications using the
         // same keys. So, we sliently drop this notification.
         this._persistentIds.push(object.persistentId);
+
+        // NOTE(ibash) for superhuman we want to keep an eye on these errors -
+        // so throw them in their own call stack so that they get caught by
+        // bugsnag.
+        setTimeout(() => {
+          throw error
+        }, 0)
         return
       } else {
         throw error

--- a/src/parser.js
+++ b/src/parser.js
@@ -201,7 +201,7 @@ module.exports = class Parser extends EventEmitter {
     // Messages with no content are valid; just use the default protobuf for
     // that tag.
     if (this._messageSize === 0) {
-      this.emit('message', protobuf);
+      this.emit('message', {tag: this._messageTag, object: {}});
       this._getNextMessage();
       return;
     }
@@ -223,10 +223,7 @@ module.exports = class Parser extends EventEmitter {
       bytes : Buffer,
     });
 
-    this.emit('message', object);
-    if (this._messageTag === kDataMessageStanzaTag) {
-      this.emit('dataMessage', object);
-    }
+    this.emit('message', {tag: this._messageTag, object: object});
 
     if (this._messageTag === kLoginResponseTag) {
       if (this._handshakeComplete) {


### PR DESCRIPTION
This commit adds persistent ids to the login request, which is one way GCM acks them. The other way GCM acks is by keeping track of stream ids and sending those back and forth.

That needs to be done too, but at least this should help clear them periodically.
