### PR TITLE
Update changes from push2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,24 @@ You can use [electron-push-receiver](https://github.com/MatthieuLemoine/electron
 ### Node
 
 ```javascript
-const { register, listen } = require('push-receiver');
+const { register, listen } = require('push-receiver-v2');
+
+// Firebase config
+const config = {
+  firebase: {
+    apiKey: "XXxxXxX0x0x-Xxxx0-X0Xxxxx_0xxXx_XX0xXxX",
+    appID: "1:000000000000:android:xxx0xxxx0000x000xxx000",
+    projectID: "the-app-name"
+  },
+  vapidKey: '' // optional
+};
 
 // First time
 // Register to GCM and FCM
-const credentials = await register(senderId); // You should call register only once and then store the credentials somewhere
+const credentials = await register(config); // You should call register only once and then store the credentials somewhere
 storeCredentials(credentials) // Store credentials to use it later
 const fcmToken = credentials.fcm.token; // Token to use to send notifications
 sendTokenToBackendOrWhatever(fcmToken);
-
 
 // Next times
 const credentials = getSavedCredentials() // get your saved credentials from somewhere (file, db, etc...)
@@ -69,3 +78,5 @@ To test, you can use the [send script](scripts/send/index.js) provided in this r
 ```
 node scripts/send --serverKey="<FIREBASE_SERVER_KEY>" --token="<FIREBASE_TOKEN>"
 ```
+
+Note: The `send` endpoint is deprecated and removed as of June 20, 2024: https://firebase.google.com/support/faq#fcm-depr-features

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,0 @@
-# TODO
-
-- Pass persistentId during login to avoid duplicate notifications
-- FCM token expiration

--- a/example/index.js
+++ b/example/index.js
@@ -1,15 +1,34 @@
 const { register, listen } = require('../src');
-const senderId = require('yargs').argv.senderId;
+const apiKey = require('yargs').argv.apiKey;
+const appID = require('yargs').argv.appID;
+const projectID = require('yargs').argv.projectID;
 
-if (!senderId) {
-  console.error('Missing senderId');
+if (!apiKey) {
+  console.error('Missing apiKey');
   return;
 }
+else if (!appID) {
+  console.error('Missing appID');
+  return;
+}
+else if (!projectID) {
+  console.error('Missing projectID');
+  return;
+}
+
+const config = {
+  firebase: {
+    apiKey,
+    appID,
+    projectID
+  },
+  vapidKey: ''
+};
 
 (async () => {
   // First time
   // Register to GCM and FCM
-  const credentials = await register(senderId); // You should call register only once and then store the credentials somewhere
+  const credentials = await register(config); // You should call register only once and then store the credentials somewhere
   const fcmToken = credentials.fcm.token; // Token to use to send notifications
   console.log('Use this following token to send a notification', fcmToken);
   // persistentIds is the list of notification ids received to avoid receiving all already received notifications on start.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/push-receiver",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description":
     "A module to subscribe to GCM/FCM and receive notifications within a node process.",
   "main": "src/index.js",

--- a/scripts/register/index.js
+++ b/scripts/register/index.js
@@ -1,14 +1,33 @@
 const { register } = require('../../src');
-const senderId = require('yargs').argv.senderId;
+const apiKey = require('yargs').argv.apiKey;
+const appID = require('yargs').argv.appID;
+const projectID = require('yargs').argv.projectID;
 
-if (!senderId) {
-  console.error('Missing senderId');
+if (!apiKey) {
+  console.error('Missing apiKey');
+  return;
+}
+else if (!appID) {
+  console.error('Missing appID');
+  return;
+}
+else if (!projectID) {
+  console.error('Missing projectID');
   return;
 }
 
+const config = {
+  firebase: {
+    apiKey,
+    appID,
+    projectID
+  },
+  vapidKey: ''
+};
+
 (async () => {
   try {
-    await register(senderId);
+    await register(config);
     console.log('Successfully registered');
   } catch (e) {
     console.error('Error during registration');

--- a/scripts/send/index.js
+++ b/scripts/send/index.js
@@ -1,3 +1,5 @@
+// Note: The send endpoint is deprecated and removed as of June 20, 2024: https://firebase.google.com/support/faq#fcm-depr-features
+
 const request = require('request-promise');
 const argv = require('yargs').argv;
 

--- a/src/fcm/index.js
+++ b/src/fcm/index.js
@@ -2,35 +2,77 @@ const crypto = require('crypto');
 const request = require('request-promise');
 const { escape } = require('../utils/base64');
 
-const FCM_SUBSCRIBE = 'https://fcm.googleapis.com/fcm/connect/subscribe';
+const FIREBASE_INSTALLATION =
+  'https://firebaseinstallations.googleapis.com/v1/';
+const FCM_REGISTRATION = 'https://fcmregistrations.googleapis.com/v1/';
 const FCM_ENDPOINT = 'https://fcm.googleapis.com/fcm/send';
 
-module.exports = registerFCM;
+module.exports = { installFCM, registerFCM };
 
-async function registerFCM({ senderId, token }) {
-  const keys = await createKeys();
+function generateFirebaseFID() {
+  // A valid FID has exactly 22 base64 characters, which is 132 bits, or 16.5
+  // bytes. our implementation generates a 17 byte array instead.
+  const fid = crypto.randomBytes(17);
+
+  // Replace the first 4 random bits with the constant FID header of 0b0111.
+  fid[0] = 0b01110000 + fid[0] % 0b00010000;
+
+  return fid.toString('base64');
+}
+
+async function installFCM(config) {
   const response = await request({
-    url     : FCM_SUBSCRIBE,
+    url : `${FIREBASE_INSTALLATION}projects/${
+      config.firebase.projectID
+    }/installations`,
     method  : 'POST',
     headers : {
-      'Content-Type' : 'application/x-www-form-urlencoded',
+      'x-firebase-client' : btoa(
+        JSON.stringify({ heartbeats : [], version : 2 })
+      ).toString('base64'),
+      'x-goog-api-key' : config.firebase.apiKey,
     },
-    form : {
-      authorized_entity : senderId,
-      endpoint          : `${FCM_ENDPOINT}/${token}`,
-      encryption_key    : keys.publicKey
-        .replace(/=/g, '')
-        .replace(/\+/g, '-')
-        .replace(/\//g, '_'),
-      encryption_auth : keys.authSecret
-        .replace(/=/g, '')
-        .replace(/\+/g, '-')
-        .replace(/\//g, '_'),
+    body : {
+      appId       : config.firebase.appID,
+      authVersion : 'FIS_v2',
+      fid         : generateFirebaseFID(),
+      sdkVersion  : 'w:0.6.4',
     },
+    json : true,
+  });
+  return response;
+}
+
+async function registerFCM(config) {
+  const keys = await createKeys();
+  const response = await request({
+    url : `${FCM_REGISTRATION}projects/${
+      config.firebase.projectID
+    }/registrations`,
+    method  : 'POST',
+    headers : {
+      'x-goog-api-key'                     : config.firebase.apiKey,
+      'x-goog-firebase-installations-auth' : config.authToken,
+    },
+    body : {
+      web : {
+        applicationPubKey : config.vapidKey,
+        auth              : keys.authSecret
+          .replace(/=/g, '')
+          .replace(/\+/g, '-')
+          .replace(/\//g, '_'),
+        endpoint : `${FCM_ENDPOINT}/${config.token}`,
+        p256dh   : keys.publicKey
+          .replace(/=/g, '')
+          .replace(/\+/g, '-')
+          .replace(/\//g, '_'),
+      },
+    },
+    json : true,
   });
   return {
     keys,
-    fcm : JSON.parse(response),
+    fcm : response,
   };
 }
 

--- a/src/register/index.js
+++ b/src/register/index.js
@@ -1,17 +1,18 @@
 const uuidv4 = require('uuid/v4');
 const { register: registerGCM } = require('../gcm');
-const registerFCM = require('../fcm');
+const { installFCM, registerFCM } = require('../fcm');
 
 module.exports = register;
 
-async function register(senderId) {
+async function register(config) {
   // Should be unique by app - One GCM registration/token by app/appId
   const appId = `wp:receiver.push.com#${uuidv4()}`;
   const subscription = await registerGCM(appId);
+  const installation = await installFCM(config);
   const result = await registerFCM({
-    token : subscription.token,
-    senderId,
-    appId,
+    ...config,
+    authToken : installation.authToken.token,
+    token     : subscription.token,
   });
   // Need to be saved by the client
   return Object.assign({}, result, { gcm : subscription });


### PR DESCRIPTION
Changes taken from `https://github.com/javajuice1337/push-receiver-v2` (Ty @javajuice1337 for updating the register api🙏🏻 ) I just diffed our lib an theirs. I'm not switching over to that lib since it doesn't seem to be actively maintained and I expect while we are using this firebase approach we will need to make future changes at some point. But hopefully we won't be on fcm for too much longer.

The primary change we are interested in is the new firebase auth api since we are seeing deprecation errors for our native firebase usage.

I've tested locally and will test on staging after we publish.

Related prs:
https://github.com/superhuman/electron-push-receiver/pull/5
https://github.com/superhuman/desktop/pull/25507