### PR TITLE
Surface decrypt errors after recording persistent ids

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -16,6 +16,11 @@ const { load } = require('protobufjs');
 const HOST = 'mtalk.google.com';
 const PORT = 5228;
 const MAX_RETRY_TIMEOUT = 15;
+const DECRYPTION_ERRORS_TO_REPORT = [
+  'Unsupported state or unable to authenticate data',
+  'crypto-key is missing',
+  'salt is missing',
+];
 
 let proto = null;
 
@@ -191,24 +196,11 @@ module.exports = class Client extends EventEmitter {
     try {
       message = decrypt(object, this._credentials.keys);
     } catch (error) {
-      switch (true) {
-        case error.message.includes(
-          'Unsupported state or unable to authenticate data'
-        ):
-        case error.message.includes('crypto-key is missing'):
-        case error.message.includes('salt is missing'):
-          // NOTE(ibash) Periodically we're unable to decrypt notifications. In
-          // all cases we've been able to receive future notifications using the
-          // same keys. So, we silently drop this notification.
-          console.warn(
-            'Message dropped as it could not be decrypted: ' + error.message
-          );
-          this._persistentIds.push(object.persistentId);
-          return;
-        default: {
-          throw error;
-        }
+      if (isReportableDecryptionError(error)) {
+        this._persistentIds.push(object.persistentId);
       }
+      this._emitError(error);
+      return;
     }
 
     // Maintain persistentIds updated with the very last received value
@@ -220,4 +212,15 @@ module.exports = class Client extends EventEmitter {
       persistentId : object.persistentId,
     });
   }
+
+  _emitError(error) {
+    // Let Parser advance past this packet before consumers handle the error.
+    setImmediate(() => this.emit('error', error));
+  }
 };
+
+function isReportableDecryptionError(error) {
+  return DECRYPTION_ERRORS_TO_REPORT.some(message =>
+    error.message.includes(message)
+  );
+}

--- a/src/client.js
+++ b/src/client.js
@@ -16,11 +16,6 @@ const { load } = require('protobufjs');
 const HOST = 'mtalk.google.com';
 const PORT = 5228;
 const MAX_RETRY_TIMEOUT = 15;
-const DECRYPTION_ERRORS_TO_REPORT = [
-  'Unsupported state or unable to authenticate data',
-  'crypto-key is missing',
-  'salt is missing',
-];
 
 let proto = null;
 
@@ -220,7 +215,9 @@ module.exports = class Client extends EventEmitter {
 };
 
 function isReportableDecryptionError(error) {
-  return DECRYPTION_ERRORS_TO_REPORT.some(message =>
-    error.message.includes(message)
-  );
+  return [
+    'Unsupported state or unable to authenticate data',
+    'crypto-key is missing',
+    'salt is missing',
+  ].some(message => error.message.includes(message));
 }

--- a/src/gcm/index.js
+++ b/src/gcm/index.js
@@ -8,8 +8,8 @@ const { toBase64 } = require('../utils/base64');
 
 // Hack to fix PHONE_REGISTRATION_ERROR #17 when bundled with webpack
 // https://github.com/dcodeIO/protobuf.js#browserify-integration
-protobuf.util.Long = Long
-protobuf.configure()
+protobuf.util.Long = Long;
+protobuf.configure();
 
 const serverKey = toBase64(Buffer.from(fcmKey));
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1,0 +1,84 @@
+jest.mock('../src/utils/decrypt');
+
+const Client = require('../src/client');
+const decrypt = require('../src/utils/decrypt');
+
+const KEYS = {
+  authSecret : 'auth-secret',
+  privateKey : 'private-key',
+};
+
+function createClient(persistentIds = []) {
+  return new Client({ keys : KEYS }, { persistentIds });
+}
+
+describe('Client', () => {
+  describe('_onDataMessage', () => {
+    beforeEach(() => {
+      decrypt.mockReset();
+    });
+
+    [
+      'Unsupported state or unable to authenticate data',
+      'crypto-key is missing',
+      'salt is missing',
+    ].forEach(errorMessage => {
+      it(`emits "${errorMessage}" after recording the persistent id`, done => {
+        const client = createClient();
+        const object = { persistentId : 'persistent-id' };
+        const decryptionError = new Error(errorMessage);
+
+        decrypt.mockImplementation(() => {
+          throw decryptionError;
+        });
+
+        client.on('error', error => {
+          expect(error).toBe(decryptionError);
+          expect(client._persistentIds).toEqual(['persistent-id']);
+          expect(decrypt).toHaveBeenCalledWith(object, KEYS);
+          done();
+        });
+
+        client._onDataMessage(object);
+        expect(client._persistentIds).toEqual(['persistent-id']);
+      });
+    });
+
+    it('emits unrelated decrypt errors without recording the persistent id', done => {
+      const client = createClient();
+      const object = { persistentId : 'persistent-id' };
+      const decryptionError = new Error('unexpected decrypt failure');
+
+      decrypt.mockImplementation(() => {
+        throw decryptionError;
+      });
+
+      client.on('error', error => {
+        expect(error).toBe(decryptionError);
+        expect(client._persistentIds).toEqual([]);
+        done();
+      });
+
+      client._onDataMessage(object);
+      expect(client._persistentIds).toEqual([]);
+    });
+
+    it('records and emits successfully decrypted messages', () => {
+      const client = createClient();
+      const object = { persistentId : 'persistent-id' };
+      const message = { title : 'Hello' };
+      const onNotification = jest.fn();
+
+      decrypt.mockReturnValue(message);
+      client.on('ON_NOTIFICATION_RECEIVED', onNotification);
+
+      client._onDataMessage(object);
+
+      expect(client._persistentIds).toEqual(['persistent-id']);
+      expect(onNotification).toHaveBeenCalledWith({
+        notification : message,
+        persistentId : 'persistent-id',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Stop `_onDataMessage` from silently warning and returning for decryption failures that should be visible to consumers.
- Keep recording the message `persistentId` for known undecryptable messages so reconnects do not redeliver the same packet.
- Surface all decrypt failures through the client `error` path, deferred until the next turn so the parser can advance before app-level error handling reports the failure.
- Add focused Jest coverage for known undecryptable errors, unrelated decrypt failures, and successful notification delivery.
- Carry forward the existing two-semicolon GCM lint fix needed for `yarn lint` on `master`.

Requested from Brian review on #13. I checked the desktop native path: a synchronous throw from message handling would reach desktop uncaught-error reporting, but it can interrupt parser advancement. This keeps the change inside `push-receiver` and does not require `electron-push-receiver` to take on extra responsibility.

## Validation

- `yarn test test/client.test.js --runInBand`
- `yarn lint`
- `./node_modules/.bin/eslint test/client.test.js`